### PR TITLE
 Major refactor and update for 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ notifications:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("InvertedIndices"); Pkg.test("InvertedIndices"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'using Pkg; cd(Pkg.dir("InvertedIndices")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ os:
   - linux
   - osx
 julia:
-  # - release
+  - 0.7
+  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false
@@ -14,4 +16,4 @@ notifications:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("InvertedIndices"); Pkg.test("InvertedIndices"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("InvertedIndices")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; cd(Pkg.dir("InvertedIndices")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,14 @@ environment:
   - julia_version: 1
   - julia_version: nightly
 
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+matrix:
+  allow_failures:
+  - julia_version: nightly
+
 branches:
   only:
     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
 environment:
   matrix:
-#  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-#  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
 branches:
   only:
@@ -17,18 +16,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"InvertedIndices\"); Pkg.build(\"InvertedIndices\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"InvertedIndices\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -39,7 +39,7 @@ end
 NIdx{N} = Union{CartesianIndex{N}, AbstractArray{CartesianIndex{N}}, AbstractArray{Bool,N}}
 @inline spanned_indices(inds, I::Tuple{InvertedIndex{<:NIdx{0}},Vararg{Any}}) = ()
 @inline spanned_indices(inds, I::Tuple{InvertedIndex{<:NIdx{1}},Vararg{Any}}) = (Base.uncolon(inds, (:, Base.tail(I)...)).indices,)
-@inline function spanned_indices{N}(inds, I::Tuple{InvertedIndex{<:NIdx{N}},Vararg{Any}})
+@inline function spanned_indices(inds, I::Tuple{InvertedIndex{<:NIdx{N}},Vararg{Any}}) where N
     heads, tails = Base.IteratorsMD.split(inds, Val{N})
     (Base.front(heads)..., Base.uncolon((heads[end], tails...), (:, Base.tail(I)...)).indices)
 end

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -2,6 +2,8 @@ module InvertedIndices
 
 export InvertedIndex, Not
 
+using Base: tail
+
 """
     InvertedIndex(idx)
     Not(idx)
@@ -16,32 +18,96 @@ checked to ensure that all indices in `idx` are within the bounds of the array
 dimensions (like a multidimensional logical mask or `CartesianIndex`), then the
 inverted index will similarly span multiple dimensions.
 """
-struct InvertedIndex{T}
-    skip::T
+struct InvertedIndex{S}
+    skip::S
 end
 const Not = InvertedIndex
 
-# This is a little tricky because trues isn't indices-aware, but we also don't
-# want to use fill(true) in the 1-indexed case since we want to favor BitArrays
-@inline trues(tup::Tuple{Vararg{Base.OneTo}}) = Base.trues(map(Base.unsafe_length, tup))
-@inline trues(tup::Tuple{Vararg{Base.AbstractUnitRange}}) = fill(true, tup)
+# Like Base.LogicalIndex, the InvertedIndexIterator is a pseudo-vector that is
+# just used as an iterator and does not support getindex.
+struct InvertedIndexIterator{T,S,P} <: AbstractVector{T}
+    skips::S
+    picks::P
+end
+InvertedIndexIterator(skips, picks) = InvertedIndexIterator{eltype(picks), typeof(skips), typeof(picks)}(skips, picks)
+Base.size(III::InvertedIndexIterator) = (length(III.picks) - length(III.skips),)
+
+@inline Base.iterate(I::InvertedIndexIterator) = iterate(I, (iterate(I.skips), iterate(I.picks)))
+Base.iterate(I::InvertedIndexIterator, ::Tuple{Any, Nothing}) = nothing
+@inline function Base.iterate(I::InvertedIndexIterator, (skipitr, pickitr))
+    while should_skip(skipitr, pickitr)
+        skipitr = iterate(I.skips, tail(skipitr)...)
+        pickitr = iterate(I.picks, tail(pickitr)...)
+        pickitr === nothing && return nothing
+    end
+    return (pickitr[1], (skipitr, iterate(I.picks, tail(pickitr)...)))
+end
+Base.collect(III::InvertedIndexIterator) = [i for i in III]
+
+should_skip(::Nothing, ::Any) = false
+should_skip(s::Tuple, p::Tuple) = _should_skip(s[1], p[1])
+_should_skip(s, p) = s == p
+_should_skip(s::Integer, p::CartesianIndex{1}) = s == p.I[1]
+_should_skip(s::CartesianIndex{1}, p::Integer) = s.I[1] == p
+
+@inline Base.checkbounds(::Type{Bool}, A::AbstractArray, I::InvertedIndexIterator{<:Integer}) =
+    checkbounds(Bool, A, I.skips) && eachindex(IndexLinear(), A) == eachindex(IndexLinear(), I.picks)
+@inline Base.checkbounds(::Type{Bool}, A::AbstractArray, I::InvertedIndexIterator) = checkbounds(Bool, A, I.skips) && axes(A) == axes(I.picks)
+@inline Base.checkindex(::Type{Bool}, indx::AbstractUnitRange, I::InvertedIndexIterator) = checkindex(Bool, indx, I.skips) && (indx,) == axes(I.picks)
+@inline Base.checkindex(::Type{Bool}, inds::Tuple, I::InvertedIndexIterator) = checkindex(Bool, indx, I.skips) && inds == axes(I.picks)
+
+@inline Base.ensure_indexable(I::Tuple{InvertedIndexIterator, Vararg{Any}}) = (collect(I[1]), Base.ensure_indexable(tail(I))...)
+
+Base.show(io::IO, I::InvertedIndexIterator) = show(io, collect(I))
+
+# We use a custom sort method that supports Base.LogicalIndex and CartesianIndex
+sort(A::AbstractArray) = Base.sort(A)
+sort(A::Union{Number,CartesianIndex,Base.LogicalIndex}) = A
 
 @inline function Base.to_indices(A, inds, I::Tuple{InvertedIndex, Vararg{Any}})
-    v = trues(spanned_indices(inds, I))
-    v[I[1].skip] = false
-    to_indices(A, inds, (v, Base.tail(I)...))
+    new_indices = to_indices(A, inds, (I[1].skip, tail(I)...))
+    skips = sort(new_indices[1])
+    picks = spanned_indices(inds, skips)[1]
+    return (InvertedIndexIterator(skips, picks), tail(new_indices)...)
 end
 
-# Determining the indices that the InvertedIndex spans is tricky due to partial
-# linear indexing. Lean on `Base.uncolon` until the deprecation goes through.
-@inline spanned_indices(inds, I::Tuple{InvertedIndex,Vararg{Any}}) = (Base.uncolon(inds, (:, Base.tail(I)...)).indices,)
-
-NIdx{N} = Union{CartesianIndex{N}, AbstractArray{CartesianIndex{N}}, AbstractArray{Bool,N}}
-@inline spanned_indices(inds, I::Tuple{InvertedIndex{<:NIdx{0}},Vararg{Any}}) = ()
-@inline spanned_indices(inds, I::Tuple{InvertedIndex{<:NIdx{1}},Vararg{Any}}) = (Base.uncolon(inds, (:, Base.tail(I)...)).indices,)
-@inline function spanned_indices(inds, I::Tuple{InvertedIndex{<:NIdx{N}},Vararg{Any}}) where N
-    heads, tails = Base.IteratorsMD.split(inds, Val{N})
-    (Base.front(heads)..., Base.uncolon((heads[end], tails...), (:, Base.tail(I)...)).indices)
+struct ZeroDArray{T} <: AbstractArray{T,0}
+    x::T
 end
+Base.size(::ZeroDArray) = ()
+Base.getindex(Z::ZeroDArray) = Z.x
+
+# Be careful with CartesianIndex as they splat out to a variable number of new indices and do not iterate
+function Base.to_indices(A, inds, I::Tuple{InvertedIndex{<:CartesianIndex}, Vararg{Any}})
+    new_indices = to_indices(A, inds, (I[1].skip, tail(I)...))
+    skips = ZeroDArray(I[1].skip)
+    picks, tails = spanned_indices(inds, skips)
+    return (InvertedIndexIterator(skips, picks), to_indices(A, tails, tail(I))...)
+end
+
+# Either return a CartesianRange or an axis vector
+@inline spanned_indices(inds, ::Any) = inds[1], tail(inds)
+const NIdx{N} = Union{CartesianIndex{N}, AbstractArray{CartesianIndex{N}}, AbstractArray{Bool,N}}
+@inline spanned_indices(inds, ::NIdx{0}) = CartesianIndices(()), inds
+@inline spanned_indices(inds, ::NIdx{1}) = inds[1], tail(inds)
+@inline function spanned_indices(inds, ::NIdx{N}) where N
+    heads, tails = Base.IteratorsMD.split(inds, Val(N))
+    return CartesianIndices(heads), tails
+end
+
+# It's possible more indices were specified than there were axes
+@inline spanned_indices(inds::Tuple{}, ::Any) = Base.OneTo(1), ()
+@inline spanned_indices(inds::Tuple{}, ::NIdx{0}) = CartesianIndices(()), ()
+@inline spanned_indices(inds::Tuple{}, ::NIdx{1}) = Base.OneTo(1), ()
+@inline spanned_indices(inds::Tuple{}, ::NIdx{N}) where N = CartesianIndices(ntuple(i->Base.OneTo(1), N)), ()
+
+# This is an interesting need — we need this because otherwise indexing with a
+# single multidimensional boolean array ends up comparing a multidimensional cartesian
+# index to a linear index. Does this need addressing in Base, too?
+@inline Base.to_indices(A, I::Tuple{Not{<:NIdx{1}}}) = to_indices(A, (eachindex(IndexLinear(), A),), I)
+@inline Base.to_indices(A, I::Tuple{Not{<:NIdx}}) = to_indices(A, axes(A), I)
+# Arrays of Bool are even more confusing as they're sometimes linear and sometimes not
+@inline Base.to_indices(A, I::Tuple{Not{<:AbstractArray{Bool, 1}}}) = to_indices(A, (eachindex(IndexLinear(), A),), I)
+@inline Base.to_indices(A, I::Tuple{Not{<:Union{Array{Bool}, BitArray}}}) = to_indices(A, (eachindex(A),), I)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using InvertedIndices
-using Base.Test
+using Test
 using OffsetArrays
 
 @testset "0-d" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,13 @@ using OffsetArrays
 
 @testset "0-d" begin
     A = fill(1)
-    @test A[Not(A.==1)] == []
+    @test A[Not(fill(A.==1))] == []
     @test A[Not(CartesianIndex())] == []
-    @test A[Not(A.==2)] == [1]
-    A[Not(A.==2)] = 0
+    @test A[Not(fill(A.==2))] == [1]
+    A[Not(fill(A.==2))] = fill(0)
     @test A[] == 0
+    A[Not(fill(A.==2))] .= 1
+    @test A[] == 1
 end
 
 @testset "1-d readonly" for A in (-10:13, reshape(-10:13,2,:), reshape(-10:13,3,2,:))
@@ -27,8 +29,8 @@ end
 end
 
 @testset "1-d offset readonly" for A in (OffsetArray(-10:13, -3), OffsetArray(reshape(-10:13,2,:), -5, 32), OffsetArray(reshape(-10:13,3,2,:), 4,-2,20))
-    f = first(linearindices(A))
-    l = last(linearindices(A))
+    f = first(LinearIndices(A))
+    l = last(LinearIndices(A))
     @test A[Not(f)] == A[Not(f:f)] == A[Not(A.==-10)] == collect(-9:13)
     @test @views A[Not(f)] == A[Not(f:f)] == A[Not(A.==-10)] == collect(-9:13)
     @test A[Not(l)] == A[Not(l:l)] == A[Not(A.==13)] == collect(-10:12)
@@ -44,14 +46,14 @@ end
 @testset "1-d read/write" for A in (collect(1:4), reshape(collect(1:4),2,2))
     A[Not(2:3)] = [44, 11]
     @test vec(A) == [44, 2, 3, 11]
-    A[Not(2:4)] = 0
+    A[Not(2:4)] .= 0
     @test vec(A) == [0, 2, 3, 11]
-    A[Not(1:end)] = 100
+    A[Not(1:end)] .= 100
     @test vec(A) == [0, 2, 3, 11]
-    A[Not(:)] = 100
+    A[Not(:)] .= 100
     @test vec(A) == [0, 2, 3, 11]
 
-    A[Not([])] = 0
+    A[Not([])] .= 0
     @test all(A.== 0)
 
     B = copy(A)
@@ -60,18 +62,18 @@ end
     @test A == B
 end
 
-@testset "2-d readonly" for A in (reshape(-10:13,3,:), reshape(-10:13,3,4,:))
+@testset "2-d readonly" for A in (reshape(-10:13,3,:), reshape(-10:13,3,:,1))
     @test A[Not(2), :] == (@view A[Not(2), :]) == A[[1,3],:]
     @test A[:, Not(2)] == (@view A[:, Not(2)]) == A[:,[1;3:end]]
     @test A[Not(2), Not(2)] == (@view A[Not(2), Not(2)]) == A[[1;3:end],[1;3:end]]
-    R = collect(CartesianRange(size(A)))
+    R = collect(CartesianIndices(size(A)))
     @test A[Not(first(R))] == (@view A[Not(first(R))]) == A[2:end]
     @test A[Not(R[1:2])] == (@view A[Not(R[1:2])]) == A[3:end]
     @test A[Not(iseven.(A))] == (@view A[Not(iseven.(A))]) == A[isodd.(A)] == collect(-9:2:13)
 end
 
 @testset "2-d offset readonly" for A in (OffsetArray(reshape(-10:13,3,:), -1, 0), OffsetArray(reshape(-10:13,3,4,:), -10, 20, -30),)
-    inds = indices(A)
+    inds = axes(A)
     f₁, l₁ = first(inds[1]), last(inds[1])
     f₂, l₂ = first(inds[2]), last(inds[2])
     # TODO: Re-enable these tests for 3-d after PLI deprecation
@@ -80,8 +82,8 @@ end
         @test A[f₁:l₁, Not(f₂+1)] == (@view A[f₁:l₁, Not(f₂+1)]) == A[f₁:l₁,[f₂;f₂+2:l₂]]
         @test A[Not(f₁+1), Not(f₂+1)] == (@view A[Not(f₁+1), Not(f₂+1)]) == A[[f₁,l₁],[f₂;f₂+2:l₂]]
     end
-    R = collect(CartesianRange(indices(A)))
-    @test A[Not(first(R))] == (@view A[Not(first(R))]) == A[linearindices(A)[2:end]]
-    @test A[Not(R[1:2])] == (@view A[Not(R[1:2])]) == A[linearindices(A)[3:end]]
+    R = collect(CartesianIndices(axes(A)))
+    @test A[Not(first(R))] == (@view A[Not(first(R))]) == A[LinearIndices(A)[2:end]]
+    @test A[Not(R[1:2])] == (@view A[Not(R[1:2])]) == A[LinearIndices(A)[3:end]]
     @test A[Not(iseven.(A))] == (@view A[Not(iseven.(A))]) == A[isodd.(A)] == collect(-9:2:13)
 end


### PR DESCRIPTION
Use a new lazy iterator forumalation to avoid excessive allocations (a la Base.LogicalIndex). Fixes #2 and should fix #1 (although I've not run any benchmarks yet).