### PR TITLE
Add vararg for more than Ints

### DIFF
--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -9,7 +9,9 @@ struct InvertedIndex{S}
 end
 const Not = InvertedIndex
 # Support easily inverting multiple indices without a temporary array in Not([...])
-InvertedIndex(i₁::Integer, i₂::Integer, iₓ::Integer...) = InvertedIndex(TupleVector((i₁, i₂, iₓ...)))
+function InvertedIndex(i₁::T, i₂::T, iₓ::T...)  where T
+    InvertedIndex(TupleVector((i₁, i₂, iₓ...)))
+end
 
 """
     InvertedIndex(idx)
@@ -29,7 +31,7 @@ InvertedIndex, Not
 
 
 # A very simple and primitive static array to avoid allocations for Not(1,2,3) while fulfilling the indexing API
-struct TupleVector{T<:Tuple} <: AbstractVector{Int}
+struct TupleVector{T<:Tuple} <: AbstractVector{V where V}
     data::T
 end
 Base.size(::TupleVector{<:NTuple{N}}) where {N} = (N,)

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -8,16 +8,24 @@ struct InvertedIndex{S}
     skip::S
 end
 const Not = InvertedIndex
+
 # Support easily inverting multiple indices without a temporary array in Not([...])
 function InvertedIndex(i₁::T, i₂::T, iₓ::T...)  where T
     InvertedIndex(TupleVector((i₁, i₂, iₓ...)))
 end
 
+function DataFrames.InvertedIndices.InvertedIndex(i₁, i₂, iₓ...)
+    # use Vector{Any} to avoid unwanted promotion
+    InvertedIndex(Any[i₁, i₂, iₓ...])
+end
+
 """
-    InvertedIndex(idx)
-    Not(idx)
+    InvertedIndex(idx...)
+    Not(idx...)
 
 Construct an inverted index, selecting all indices not in the passed `idx`.
+If `idx` is more than one positional argument the selector is converted to
+a vector of these arguments.
 
 Upon indexing into an array, the `InvertedIndex` behaves like a 1-dimensional
 collection of the indices of the array that are not in `idx`. Bounds are

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -39,7 +39,7 @@ InvertedIndex, Not
 
 
 # A very simple and primitive static array to avoid allocations for Not(1,2,3) while fulfilling the indexing API
-struct TupleVector{T<:Tuple} <: AbstractVector{V where V}
+struct TupleVector{T<:NTuple{N, V}} <: AbstractVector{V} where {N, V<:Integer}
     data::T
 end
 Base.size(::TupleVector{<:NTuple{N}}) where {N} = (N,)


### PR DESCRIPTION
Fixes #18 by allowing a vararg form of `Not(inds...)` for any type by expanding the type signature of the bootstrapped `SVector` type. 

Let me know if this hurts performance. 