### PR TITLE
Improve support for Not with multiple indices passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InvertedIndices"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
-version = "1.2.0"
+version = "1.3.0"
 
 [compat]
 julia = "0.7, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 version = "1.3.0"
 
 [compat]
-julia = "0.7, 1.0"
+julia = "1.6"
 
 [extras]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -20,14 +20,14 @@ end
 """
     NotMultiIndex(indices)
 
-    An unexported type that is meant to signal that `Not` was called with
-    multiple indices that were not all integer. This is meant to allow for
-    packages that allow for non-integer indexing to define custom handling
-    of such cases.
+An unexported type that is meant to signal that `Not` was called with
+multiple indices that were not all integer. This is meant to allow for
+packages that support non-integer indexing to define custom handling
+of such cases.
 
-    In particular `Base.to_indices` is on purpose not supported for values
-    of this type and proper handling of such `Not` index must be handled
-    explicitly by packages opting-in for support of non-integer indices.
+In particular `Base.to_indices` is on purpose not supported for values
+of this type and proper handling of such `Not` index must be handled
+explicitly by packages opting-in for support of non-integer indices.
 """
 struct NotMultiIndex
     indices
@@ -200,6 +200,6 @@ end
                         error("type NamedTuple has no fields $(join(I.skip, ", "))")
 
 @inline Base.to_indices(A, inds, I::Tuple{InvertedIndex{NotMultiIndex}, Vararg{Any}}) =
-    throw(ArgumentError("Multiple arguments other than integers is not supported."))
+    throw(ArgumentError("Multiple arguments other than integers are not supported."))
 
 end # module

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -18,7 +18,7 @@ function InvertedIndex(i₁::Integer, i₂::Integer, iₓ::Integer...)
 end
 
 """
-    GeneralNotMultiIndex(indices)
+    NotMultiIndex(indices)
 
     An unexported type that is meant to signal that `Not` was called with
     multiple indices that were not all integer. This is meant to allow for
@@ -29,12 +29,12 @@ end
     of this type and proper handling of such `Not` index must be handled
     explicitly by packages opting-in for support of non-integer indices.
 """
-struct GeneralNotMultiIndex
+struct NotMultiIndex
     indices
 end
 
 function InvertedIndex(i₁, i₂, iₓ...)
-    InvertedIndex(GeneralNotMultiIndex((i₁, i₂, iₓ...)))
+    InvertedIndex(NotMultiIndex((i₁, i₂, iₓ...)))
 end
 
 """
@@ -199,8 +199,7 @@ end
     I.skip ⊆ keys(nt) ? Base.structdiff(nt, NamedTuple{I.skip}) :
                         error("type NamedTuple has no fields $(join(I.skip, ", "))")
 
-@inline Base.to_indices(A, inds, I::Tuple{InvertedIndex{GeneralNotMultiIndex}, Vararg{Any}}) =
-    throw(ArgumentError("Conversion of multiple arguments other than integers " *
-                        "of homogeneous type is not supported by `Not`."))
+@inline Base.to_indices(A, inds, I::Tuple{InvertedIndex{NotMultiIndex}, Vararg{Any}}) =
+    throw(ArgumentError("Multiple arguments other than integers is not supported."))
 
 end # module

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -8,8 +8,34 @@ struct InvertedIndex{S}
     skip::S
 end
 const Not = InvertedIndex
+
+nonBool2Int(x::Bool) = throw(ArgumentError("invalid index $x of type Bool"))
+nonBool2Int(x::Integer) = Int(x)
+
 # Support easily inverting multiple indices without a temporary array in Not([...])
-InvertedIndex(i₁::Integer, i₂::Integer, iₓ::Integer...) = InvertedIndex(TupleVector((i₁, i₂, iₓ...)))
+function InvertedIndex(i₁::Integer, i₂::Integer, iₓ::Integer...)
+    InvertedIndex(TupleVector((nonBool2Int(i₁), nonBool2Int(i₂), nonBool2Int.(iₓ)...)))
+end
+
+"""
+    GeneralNotMultiIndex(indices)
+
+    An unexported type that is meant to signal that `Not` was called with
+    multiple indices that were not all integer. This is meant to allow for
+    packages that allow for non-integer indexing to define custom handling
+    of such cases.
+
+    In particular `Base.to_indices` is on purpose not supported for values
+    of this type and proper handling of such `Not` index must be handled
+    explicitly by packages opting-in for support of non-integer indices.
+"""
+struct GeneralNotMultiIndex
+    indices
+end
+
+function InvertedIndex(i₁, i₂, iₓ...)
+    InvertedIndex(GeneralNotMultiIndex((i₁, i₂, iₓ...)))
+end
 
 """
     InvertedIndex(idx)
@@ -172,5 +198,9 @@ end
 @inline Base.getindex(nt::NamedTuple, I::InvertedIndex{NTuple{N, Symbol}}) where {N} =
     I.skip ⊆ keys(nt) ? Base.structdiff(nt, NamedTuple{I.skip}) :
                         error("type NamedTuple has no fields $(join(I.skip, ", "))")
+
+@inline Base.to_indices(A, inds, I::Tuple{InvertedIndex{GeneralNotMultiIndex}, Vararg{Any}}) =
+    throw(ArgumentError("Conversion of other multiple arguments than integers " *
+                        "of homogeneous type is not supported by `Not`."))
 
 end # module

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -200,7 +200,7 @@ end
                         error("type NamedTuple has no fields $(join(I.skip, ", "))")
 
 @inline Base.to_indices(A, inds, I::Tuple{InvertedIndex{GeneralNotMultiIndex}, Vararg{Any}}) =
-    throw(ArgumentError("Conversion of other multiple arguments than integers " *
+    throw(ArgumentError("Conversion of multiple arguments other than integers " *
                         "of homogeneous type is not supported by `Not`."))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,3 +162,26 @@ end
         @test @inferred(f(nt)) === (c=:c,)
     end
 end
+
+@testset "multi index" begin
+    x = Not(1, 2)
+    v = [1, 2, 3]
+    @test x.skip.data === (1, 2)
+    @test v[x] == [3]
+    x = Not(0x1, 0x2)
+    @test x.skip.data === (1, 2)
+    @test v[x] == [3]
+    x = Not(1, 0x2)
+    @test x.skip.data === (1, 2)
+    @test v[x] == [3]
+
+    @test v[Not(begin, end)] == [2]
+    @test v[Not(begin, 0x3)] == [2]
+
+    @test_throws ArgumentError v[Not(true)]
+    @test_throws ArgumentError Not(1, true)
+
+    x = Not(1, "a")
+    @test x isa InvertedIndex{InvertedIndices.GeneralNotMultiIndex}
+    @test_throws ArgumentError v[x]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,6 @@ end
     @test_throws ArgumentError Not(1, true)
 
     x = Not(1, "a")
-    @test x isa InvertedIndex{InvertedIndices.GeneralNotMultiIndex}
+    @test x isa InvertedIndex{InvertedIndices.NotMultiIndex}
     @test_throws ArgumentError v[x]
 end


### PR DESCRIPTION
If we agree to merge this PR then in DataFrames.jl we just need to add the fallback definition:
```
@inline Base.getindex(x::AbstractIndex, idx::InvertedIndices.GeneralNotMultiIndex) = x[Cols(idx.indices...)]
```

This PR is a replacement of https://github.com/JuliaData/InvertedIndices.jl/pull/22.

Additionally this PR fixes incorrect handling of `Bool` indices in cases like (I am showing current incorrect behavior):
```
julia> [1, 2, 3][Not(true, true)]
2-element Vector{Int64}:
 2
 3
```

CC @pdeffebach @nalimilan 