### PR TITLE
fix performance

### DIFF
--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -133,7 +133,17 @@ end
             (pickitr[1], (nothing, pickitr[2])) :
             (pickitr[1], (skipitr, pickitr[2]))
 end
-Base.collect(III::InvertedIndexIterator) = [i for i in III]
+function Base.collect(III::InvertedIndexIterator{T}) where {T}
+    !isconcretetype(T) && return [i for i in III] # use widening if T is not concrete
+    v = Vector{T}(undef, length(III))
+    i = 0
+    for elt in III
+        i += 1
+        @inbounds v[i] = elt
+    end
+    i != length(v) && throw(AssertionError("length of inverted index does not match iterated count"))
+    return v
+end
 
 should_skip(::Nothing, ::Any) = false
 should_skip(s::Tuple, p::Tuple) = _should_skip(s[1], p[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,7 +195,9 @@ returns(val) = _->val
             reshape(1:5*3*7*11, 5, 3, 7, 11),
         )
         I = to_indices(arr, (Not(iseven.(arr)),))[1]
-        @test all(isodd, I)
+        @test all(isodd, arr[I])
+        @test all(isodd, LinearIndices(arr)[I])
+        @test all(isodd, LinearIndices(arr)[collect(I)])
         @allocated(foreach(returns(nothing), I))
         @test @allocated(foreach(returns(nothing), I)) == 0
         @test @inferred(collect(I)) == vec(filter(!iseven, arr))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,6 +200,6 @@ returns(val) = _->val
         @test all(isodd, LinearIndices(arr)[collect(I)])
         @allocated(foreach(returns(nothing), I))
         @test @allocated(foreach(returns(nothing), I)) == 0
-        @test @inferred(collect(I)) == vec(filter(!iseven, arr))
+        @test @inferred(LinearIndices(arr)[collect(I)]) == vec(filter(!iseven, arr))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,3 +185,18 @@ end
     @test x isa InvertedIndex{InvertedIndices.NotMultiIndex}
     @test_throws ArgumentError v[x]
 end
+
+returns(val) = _->val
+@testset "type stability" begin
+    for arr in (
+            1:5,
+            reshape(1:5*3, 5, 3),
+            reshape(1:5*3*7, 5, 3, 7),
+            reshape(1:5*3*7*11, 5, 3, 7, 11),
+        )
+        I = to_indices(arr, (Not(iseven.(arr)),))[1]
+        @test all(isodd, I)
+        @allocated(foreach(returns(nothing), I))
+        @test @allocated(foreach(returns(nothing), I)) == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,5 +198,6 @@ returns(val) = _->val
         @test all(isodd, I)
         @allocated(foreach(returns(nothing), I))
         @test @allocated(foreach(returns(nothing), I)) == 0
+        @test @inferred(collect(I)) == vec(filter(!iseven, arr))
     end
 end


### PR DESCRIPTION
Previously, we had been plopping the return values of both `iterate(I.skips)` and `iterate(I.picks)` in a single tuple to use as the iteration state.  This meant that we had a type instability of the flavor:

```julia
(skipitr, pickitr)::Tuple{Union{Nothing, Tuple{_, _}}, Union{Nothing, Tuple{_, _}}
```

Julia's inference _does not like this_.  In particular, this isn't a small splittable union.  This change refactors iteration with two dramatic simplifications:

1. We no longer carry around the previously returned index from the `pickitr`.  Changing this to only worry about the _state_ from the picks gets rid of one union split and simplifies things such that the iteration of picks is lock-step with the iteration itself; we're no longer one ahead.
2. We do still need to carry around the previously returned skipper — it's the _next_ value we need to skip!  But here we can introduce a branch to either return a `(nothing, pickstate)` or a `((skipvalue, skipstate), pickstate)`, which is exactly the magic we need to get Julia to normalize the `Tuple{Union}` to a `Union{Tuple, Tuple}`.

fixes #14, fixes #27