### PR TITLE
Ensure skipped indices are converted to_indices

### DIFF
--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -116,8 +116,6 @@ Base.size(III::InvertedIndexIterator) = (length(III.picks) - length(III.skips),)
             (pickitr[1], (nothing, pickitr[2])) :
             (pickitr[1], (skipitr, pickitr[2]))
 end
-Base.iterate(I::InvertedIndexIterator, ::Tuple{Any, Nothing}) = nothing
-Base.iterate(I::InvertedIndexIterator, ::Tuple{Nothing, Nothing}) = nothing
 @inline function Base.iterate(I::InvertedIndexIterator, (_, pickstate)::Tuple{Nothing, Any})
     pickitr = iterate(I.picks, pickstate)
     pickitr === nothing && return nothing

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -133,7 +133,17 @@ end
             (pickitr[1], (nothing, pickitr[2])) :
             (pickitr[1], (skipitr, pickitr[2]))
 end
-Base.collect(III::InvertedIndexIterator) = [i for i in III]
+function Base.collect(III::InvertedIndexIterator{T}) where {T}
+    !isconcretetype(T) && return [i for i in III] # use widening if T is not concrete
+    v = Vector{T}(undef, length(III))
+    i = 0
+    for elt in III
+        i += 1
+        @inbounds v[i] = elt
+    end
+    i != length(v) && throw(AssertionError("length of inverted index does not match iterated count"))
+    return v
+end
 
 should_skip(::Nothing, ::Any) = false
 should_skip(s::Tuple, p::Tuple) = _should_skip(s[1], p[1])

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -94,19 +94,22 @@ end
 
 # Like Base.LogicalIndex, the InvertedIndexIterator is a pseudo-vector that is
 # just used as an iterator and does not support getindex.
-struct InvertedIndexIterator{T,S,P} <: AbstractVector{T}
+struct InvertedIndexIterator{T,S,P,F} <: AbstractVector{T}
     skips::S
     picks::P
+    toidx::F
 end
-InvertedIndexIterator(skips, picks) = InvertedIndexIterator{eltype(picks), typeof(skips), typeof(picks)}(skips, picks)
+InvertedIndexIterator(skips, picks, toidx) = InvertedIndexIterator{eltype(picks), typeof(skips), typeof(picks), typeof(toidx)}(skips, picks, toidx)
 Base.size(III::InvertedIndexIterator) = (length(III.picks) - length(III.skips),)
 
+_transformitr(f, ::Nothing) = nothing
+_transformitr(f, s) = (f(s[1]), s[2])
 @inline function Base.iterate(I::InvertedIndexIterator)
-    skipitr = iterate(I.skips)
+    skipitr = _transformitr(I.toidx, iterate(I.skips))
     pickitr = iterate(I.picks)
     pickitr === nothing && return nothing
     while should_skip(skipitr, pickitr)
-        skipitr = iterate(I.skips, skipitr[2])
+        skipitr = _transformitr(I.toidx, iterate(I.skips, skipitr[2]))
         pickitr = iterate(I.picks, pickitr[2])
         pickitr === nothing && return nothing
     end
@@ -125,7 +128,7 @@ end
     pickitr = iterate(I.picks, pickstate)
     pickitr === nothing && return nothing
     while should_skip(skipitr, pickitr)
-        skipitr = iterate(I.skips, tail(skipitr)...)
+        skipitr = _transformitr(I.toidx, iterate(I.skips, skipitr[2]))
         pickitr = iterate(I.picks, tail(pickitr)...)
         pickitr === nothing && return nothing
     end
@@ -181,7 +184,7 @@ uniquesort(x) = x
     new_indices = to_indices(A, inds, (I[1].skip, tail(I)...))
     skips = uniquesort(new_indices[1])
     picks = spanned_indices(inds, skips)[1]
-    return (InvertedIndexIterator(skips, picks), tail(new_indices)...)
+    return (InvertedIndexIterator(skips, picks, idx->to_indices(A, inds, (idx, tail(I)...))[1]), tail(new_indices)...)
 end
 
 struct ZeroDArray{T} <: AbstractArray{T,0}
@@ -194,7 +197,7 @@ Base.getindex(Z::ZeroDArray) = Z.x
 function Base.to_indices(A, inds, I::Tuple{InvertedIndex{<:CartesianIndex}, Vararg{Any}})
     skips = ZeroDArray(I[1].skip)
     picks, tails = spanned_indices(inds, skips)
-    return (InvertedIndexIterator(skips, picks), to_indices(A, tails, tail(I))...)
+    return (InvertedIndexIterator(skips, picks, idx->to_indices(A, inds, (idx, tail(I)...))[1]), to_indices(A, tails, tail(I))...)
 end
 
 # Either return a CartesianRange or an axis vector

--- a/src/InvertedIndices.jl
+++ b/src/InvertedIndices.jl
@@ -101,15 +101,39 @@ end
 InvertedIndexIterator(skips, picks) = InvertedIndexIterator{eltype(picks), typeof(skips), typeof(picks)}(skips, picks)
 Base.size(III::InvertedIndexIterator) = (length(III.picks) - length(III.skips),)
 
-@inline Base.iterate(I::InvertedIndexIterator) = iterate(I, (iterate(I.skips), iterate(I.picks)))
+@inline function Base.iterate(I::InvertedIndexIterator)
+    skipitr = iterate(I.skips)
+    pickitr = iterate(I.picks)
+    pickitr === nothing && return nothing
+    while should_skip(skipitr, pickitr)
+        skipitr = iterate(I.skips, skipitr[2])
+        pickitr = iterate(I.picks, pickitr[2])
+        pickitr === nothing && return nothing
+    end
+    # This is a little silly, but splitting the tuple here allows inference to normalize
+    # Tuple{Union{Nothing, Tuple}, Tuple} to Union{Tuple{Nothing, Tuple}, Tuple{Tuple, Tuple}}
+    return skipitr === nothing ?
+            (pickitr[1], (nothing, pickitr[2])) :
+            (pickitr[1], (skipitr, pickitr[2]))
+end
 Base.iterate(I::InvertedIndexIterator, ::Tuple{Any, Nothing}) = nothing
-@inline function Base.iterate(I::InvertedIndexIterator, (skipitr, pickitr))
+Base.iterate(I::InvertedIndexIterator, ::Tuple{Nothing, Nothing}) = nothing
+@inline function Base.iterate(I::InvertedIndexIterator, (_, pickstate)::Tuple{Nothing, Any})
+    pickitr = iterate(I.picks, pickstate)
+    pickitr === nothing && return nothing
+    return (pickitr[1], (nothing, pickitr[2]))
+end
+@inline function Base.iterate(I::InvertedIndexIterator, (skipitr, pickstate)::Tuple)
+    pickitr = iterate(I.picks, pickstate)
+    pickitr === nothing && return nothing
     while should_skip(skipitr, pickitr)
         skipitr = iterate(I.skips, tail(skipitr)...)
         pickitr = iterate(I.picks, tail(pickitr)...)
         pickitr === nothing && return nothing
     end
-    return (pickitr[1], (skipitr, iterate(I.picks, tail(pickitr)...)))
+    return skipitr === nothing ?
+            (pickitr[1], (nothing, pickitr[2])) :
+            (pickitr[1], (skipitr, pickitr[2]))
 end
 Base.collect(III::InvertedIndexIterator) = [i for i in III]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,3 +185,17 @@ end
     @test x isa InvertedIndex{InvertedIndices.NotMultiIndex}
     @test_throws ArgumentError v[x]
 end
+
+@testset "type stability" begin
+    for arr in (
+            1:5,
+            reshape(1:5*3, 5, 3),
+            reshape(1:5*3*7, 5, 3, 7),
+            reshape(1:5*3*7*11, 5, 3, 7, 11),
+        )
+        I = to_indices(arr, (Not(iseven.(arr)),))[1]
+        @test all(isodd, I)
+        @allocated(foreach(Returns(nothing), I))
+        @test @allocated(foreach(Returns(nothing), I)) == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,3 +201,36 @@ returns(val) = _->val
         @test @inferred(collect(I)) == vec(filter(!iseven, arr))
     end
 end
+
+struct NamedVector{T,A,B} <: AbstractArray{T,1}
+    data::A
+    names::B
+end
+function NamedVector(data, names)
+    @assert size(data) == size(names)
+    NamedVector{eltype(data), typeof(data), typeof(names)}(data, names)
+end
+Base.size(n::NamedVector) = size(n.data)
+Base.getindex(n::NamedVector, i::Int) = n.data[i]
+Base.to_index(n::NamedVector, name::Symbol) = findfirst(==(name), n.names)
+Base.checkbounds(::Type{Bool}, n::NamedVector, names::AbstractArray{Symbol}) = all(name in n.names for name in names)
+
+@testset "check invalid skipped indices and transform them" begin
+    @test_throws "invalid index" [1, 2, 3, 4][Not(Not([1.5]))]
+    @test_throws "invalid index" [1, 2, 3, 4][Not(Integer[true, 2])]
+
+    n = NamedVector(1:4, [:a, :b, :c, :d]);
+    @test n[Not([:a,:b])] == n[Not(1:2)] == [3, 4]
+    @test n[Not([:c,:d])] == n[Not(3:4)] == [1, 2]
+    @test n[Not(:a)] == n[Not(1)] == [2,3,4]
+    @test n[Not(:b)] == n[Not(2)] == [1,3,4]
+
+    # Unsorted index names are broken
+    n = NamedVector(1:4, [:d, :b, :c, :a]);
+    @test_broken n[Not([:a,:b])] == n[Not([4,2])]== n[[:d,:c]] == [1, 3]
+    @test_broken n[Not([:c,:d])] == n[Not([3,1])] == n[[:b,:a]] == [2, 4]
+    @test n[Not(:a)] == n[Not(4)] == [1,2,3]
+    @test n[Not(:b)] == n[Not(2)] == [1,3,4]
+    @test n[Not(:c)] == n[Not(3)] == [1,2,4]
+    @test n[Not(:d)] == n[Not(1)] == [2,3,4]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,6 +186,7 @@ end
     @test_throws ArgumentError v[x]
 end
 
+returns(val) = _->val
 @testset "type stability" begin
     for arr in (
             1:5,
@@ -195,7 +196,7 @@ end
         )
         I = to_indices(arr, (Not(iseven.(arr)),))[1]
         @test all(isodd, I)
-        @allocated(foreach(Returns(nothing), I))
-        @test @allocated(foreach(Returns(nothing), I)) == 0
+        @allocated(foreach(returns(nothing), I))
+        @test @allocated(foreach(returns(nothing), I)) == 0
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,5 +198,6 @@ returns(val) = _->val
         @test all(isodd, I)
         @allocated(foreach(returns(nothing), I))
         @test @allocated(foreach(returns(nothing), I)) == 0
+        @test @inferred(collect(I)) == vec(filter(!iseven, arr))
     end
 end


### PR DESCRIPTION
(built atop the perf work for simplicity)

Fixes #31 and #7... but only if the to_indices conversion is sort stable.  Not sure what we want to do here... but perhaps we should just eagerly do this transform for non-`Int` arrays.